### PR TITLE
Add filesystem access

### DIFF
--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -19,7 +19,8 @@
         "--socket=pulseaudio",
         "--socket=fallback-x11",
         "--socket=wayland",
-         "--filesystem=xdg-download",
+        /* Remove if #983 is fixed */
+        "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.secrets"
     ],
     "modules":[

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -19,7 +19,7 @@
         "--socket=pulseaudio",
         "--socket=fallback-x11",
         "--socket=wayland",
-	  "--filesystem=xdg-download",
+         "--filesystem=xdg-download", # Remove if fixed: https://github.com/lwindolf/liferea/issues/983
         "--talk-name=org.freedesktop.secrets"
     ],
     "modules":[
@@ -55,4 +55,3 @@
         }
     ]
 }
-

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -19,6 +19,7 @@
         "--socket=pulseaudio",
         "--socket=fallback-x11",
         "--socket=wayland",
+	  "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.secrets"
     ],
     "modules":[

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -19,7 +19,7 @@
         "--socket=pulseaudio",
         "--socket=fallback-x11",
         "--socket=wayland",
-         "--filesystem=xdg-download", # Remove if fixed: https://github.com/lwindolf/liferea/issues/983
+         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.secrets"
     ],
     "modules":[


### PR DESCRIPTION
Fixes, https://github.com/lwindolf/liferea/issues/982

Liferea doesn't use [GtkFileChooserNative](https://developer.gnome.org/gtk3/stable/gtk3-GtkFileChooserNative.html) that supports [portal API](https://flatpak.github.io/xdg-desktop-portal/portal-docs.html#gdbus-org.freedesktop.portal.FileChooser) but [GtkFileChooser](https://developer.gnome.org/gtk3/stable/GtkFileChooser.html). See also https://docs.flatpak.org/en/latest/portals-gtk.html.

This breaks import/exporting feeds.

`home` is too open in my opinion and other RSS readers on Flathub also use `xdg-download`; `:ro` can't be used as write is needed.