### PR TITLE
Allow notification plugin to work

### DIFF
--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -19,6 +19,7 @@
         "--socket=pulseaudio",
         "--socket=fallback-x11",
         "--socket=wayland",
+	"--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets"
     ],
     "modules":[


### PR DESCRIPTION
It is included by default, without this error in console and no notifications:

```
Traceback (most recent call last):
  File "/app/lib/liferea/plugins/libnotify.py", line 70, in on_node_updated
    self.notification.show()
gi.repository.GLib.Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown (2)
```

Check: `flatpak run --talk-name=org.freedesktop.Notifications net.sourceforge.liferea` -> Enable Popup Notifications plugin -> Add/Update/Fetch a feed -> Notification 