### PR TITLE
Allow installing external plugins + plugin patches to enable usage under Flatpak

### DIFF
--- a/0001-getfocus-plugin.patch
+++ b/0001-getfocus-plugin.patch
@@ -1,0 +1,111 @@
+From 1fbb1a111e7784b65a68805cdb2c873b6437ffa5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Marciniak?= <sunwire+git@gmail.com>
+Date: Fri, 28 Jan 2022 19:00:15 +0100
+Subject: [PATCH 1/2] getfocus plugin use XDG_CONFIG_HOME path when is set
+
+---
+ plugins/getfocus.plugin |  2 +-
+ plugins/getfocus.py     | 18 +++++++++++-------
+ 2 files changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/plugins/getfocus.plugin b/plugins/getfocus.plugin
+index bb65ee1a..343ce19b 100644
+--- a/plugins/getfocus.plugin
++++ b/plugins/getfocus.plugin
+@@ -5,4 +5,4 @@ IAge=2
+ Name=Get focus!
+ Description=An automatic visual "focus mode" for Liferea, that makes the feedlist less prominent by change its opacity.
+ Authors=Paweł Marciniak
+-Copyright=Copyright © 2021 Paweł Marciniak
++Copyright=Copyright © 2021-2022 Paweł Marciniak
+diff --git a/plugins/getfocus.py b/plugins/getfocus.py
+index 479ad3b1..80f544c7 100644
+--- a/plugins/getfocus.py
++++ b/plugins/getfocus.py
+@@ -1,7 +1,7 @@
+ """
+ GetFocus! Liferea plugin
+ 
+-Copyright (C) 2021 Paweł Marciniak <sunwire+liferea@gmail.com
++Copyright (C) 2021-2022 Paweł Marciniak <sunwire+liferea@gmail.com
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+@@ -16,7 +16,8 @@ GNU Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ """
+-import pathlib
++import os
++from pathlib import Path
+ import gettext
+ from gi.repository import GObject, Gtk, Liferea, PeasGtk
+ 
+@@ -29,12 +30,15 @@ except FileNotFoundError:
+ else:
+     _ = t.gettext
+ 
+-file_config = 'opacity.conf'
++FILE_CONFIG = 'opacity.conf'
+ 
+ 
+ def get_path():
+-    return pathlib.Path.joinpath(pathlib.Path.home(),
+-                                 ".config/liferea/plugins/getfocus")
++    config_path = "liferea/plugins/getfocus"
++    config_home = os.getenv('XDG_CONFIG_HOME')
++    if config_home:
++        return Path.joinpath(Path(config_home), config_path)
++    return Path.joinpath(Path.home(), ".config", config_path)
+ 
+ 
+ class GetFocusPlugin(GObject.Object, Liferea.ShellActivatable):
+@@ -69,7 +73,7 @@ class GetFocusPlugin(GObject.Object, Liferea.ShellActivatable):
+ 
+     def read_opacity_from_file(self):
+         path = get_path()
+-        file_path = path / file_config
++        file_path = path / FILE_CONFIG
+         if file_path.exists():
+             self.opacity = float(file_path.read_text())
+ 
+@@ -125,5 +129,5 @@ class GetFocusConfigure(GObject.Object, PeasGtk.Configurable):
+     def save_opacity_to_file(self, widget):
+         path = get_path()
+         path.mkdir(0o700, True, True)
+-        file_path = path / file_config
++        file_path = path / FILE_CONFIG
+         file_path.write_text(str(self.opacity))
+-- 
+2.35.1
+
+
+From 1710e6257d95af8bb4bbb62c52922459341734dd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Marciniak?= <sunwire+git@gmail.com>
+Date: Sat, 29 Jan 2022 08:11:12 +0100
+Subject: [PATCH 2/2] simplify the get_path code
+
+---
+ plugins/getfocus.py | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/plugins/getfocus.py b/plugins/getfocus.py
+index 80f544c7..6c63ff65 100644
+--- a/plugins/getfocus.py
++++ b/plugins/getfocus.py
+@@ -35,10 +35,8 @@ FILE_CONFIG = 'opacity.conf'
+ 
+ def get_path():
+     config_path = "liferea/plugins/getfocus"
+-    config_home = os.getenv('XDG_CONFIG_HOME')
+-    if config_home:
+-        return Path.joinpath(Path(config_home), config_path)
+-    return Path.joinpath(Path.home(), ".config", config_path)
++    config_home = os.getenv('XDG_CONFIG_HOME',Path.joinpath(Path.home(), ".config"))
++    return Path.joinpath(Path(config_home), config_path)
+ 
+ 
+ class GetFocusPlugin(GObject.Object, Liferea.ShellActivatable):
+-- 
+2.35.1
+

--- a/0001-pane-plugin.patch
+++ b/0001-pane-plugin.patch
@@ -1,0 +1,49 @@
+From 300b22178b10940bc911fb655aa8a2c7946d7963 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Marciniak?= <sunwire+git@gmail.com>
+Date: Sat, 29 Jan 2022 09:52:15 +0100
+Subject: [PATCH 3/4] pane plugin use XDG_CONFIG_HOME path when is set
+
+---
+ plugins/pane.plugin | 2 +-
+ plugins/pane.py     | 8 +++++---
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/plugins/pane.plugin b/plugins/pane.plugin
+index a0df2abb..d14a8248 100644
+--- a/plugins/pane.plugin
++++ b/plugins/pane.plugin
+@@ -5,4 +5,4 @@ IAge=2
+ Name=Pane position workaround
+ Description=Set pane position, workaround.
+ Authors=Paweł Marciniak
+-Copyright=Copyright © 2021 Paweł Marciniak
++Copyright=Copyright © 2021-2022 Paweł Marciniak
+diff --git a/plugins/pane.py b/plugins/pane.py
+index 7317acfe..84f9465b 100644
+--- a/plugins/pane.py
++++ b/plugins/pane.py
+@@ -12,7 +12,8 @@ GNU Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ """
+-import pathlib
++import os
++from pathlib import Path
+ import gettext
+ from threading import Thread
+ from time import sleep
+@@ -31,8 +32,9 @@ FILE_CONFIG = 'pane.conf'
+ 
+ 
+ def get_path():
+-    return pathlib.Path.joinpath(pathlib.Path.home(),
+-                                 ".config/liferea/plugins/pane")
++    config_path = "liferea/plugins/pane"
++    config_home = os.getenv('XDG_CONFIG_HOME',Path.joinpath(Path.home(), ".config"))
++    return Path.joinpath(Path(config_home), config_path)
+ 
+ 
+ class PaneWorkaroundPlugin(GObject.Object, Liferea.ShellActivatable):
+-- 
+2.35.0
+

--- a/0001-plugin-installer.patch
+++ b/0001-plugin-installer.patch
@@ -1,0 +1,54 @@
+From ada4158de9d8cb0127d3d37d495e413e4c39482b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Marciniak?= <sunwire+git@gmail.com>
+Date: Sat, 29 Jan 2022 11:14:41 +0100
+Subject: [PATCH 4/4] plugin-installer use XDG_DATA_HOME path when it is set
+
+---
+ plugins/plugin-installer.py | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/plugins/plugin-installer.py b/plugins/plugin-installer.py
+index 442c9452..74a6bb21 100644
+--- a/plugins/plugin-installer.py
++++ b/plugins/plugin-installer.py
+@@ -19,6 +19,7 @@
+ 
+ import urllib.request, json
+ import os, sys, glob, shutil, subprocess
++from pathlib import Path
+ import gi
+ 
+ gi.require_version('Gtk', '3.0')
+@@ -64,13 +65,15 @@ class AppActivatable(GObject.Object, Liferea.ShellActivatable):
+ 
+ class PluginBrowser(Gtk.Window):
+     SCHEMA_ID = "net.sf.liferea.plugins"
++    SCHEMA_PATH = "glib-2.0/schemas/"
++    PLUGIN_PATH = "liferea/plugins"
+ 
+     def __init__(self):
+         Gtk.Window.__init__(self, title=_("Plugin Installer"))
+ 
+-        # FIXME: using safe XDG paths would be better
+-        self.target_dir = os.path.expanduser("~/.local/share/liferea/plugins/")
+-        self.schema_dir = os.path.expanduser("~/.local/share/glib-2.0/schemas/")
++        self.data_home_path = os.getenv('XDG_DATA_HOME',Path.joinpath(Path.home(), ".local/share"))
++        self.target_dir = Path.joinpath(Path(self.data_home_path), self.PLUGIN_PATH)
++        self.schema_dir = Path.joinpath(Path(self.data_home_path), self.SCHEMA_PATH)
+ 
+         self.set_border_width(10)
+         self.set_default_size(600,300)
+@@ -91,8 +94,8 @@ class PluginBrowser(Gtk.Window):
+             try:
+                 name = next(iter(ref))
+                 installed = False
+-                if(os.path.isfile('%s%s.plugin' % (self.target_dir, ref[name]['module'])) or
+-                   os.path.isdir('%s%s' % (self.target_dir, ref[name]['module']))):
++                if(os.path.isfile('%s/%s.plugin' % (self.target_dir, ref[name]['module'])) or
++                   os.path.isdir('%s/%s' % (self.target_dir, ref[name]['module']))):
+                    installed = True
+                 if not 'icon' in ref[name]:
+                    ref[name]['icon'] = 'libpeas-plugin'
+-- 
+2.35.0
+

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -76,7 +76,7 @@
                 {
                     "type":"patch",
                     "path":"0001-Update-appdata-screenshot.patch"
-                }
+                },
                 {
                      "type":"patch",
                      "path":"0001-getfocus-plugin.patch"

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -9,6 +9,8 @@
         "/lib/pkgconfig",
         "/share/pkgconfig",
         "/share/aclocal",
+        "/man",
+        "/share/man",
         "*.la",
         "*.a"
     ],

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -77,6 +77,18 @@
                     "type":"patch",
                     "path":"0001-Update-appdata-screenshot.patch"
                 }
+                {
+                     "type":"patch",
+                     "path":"0001-getfocus-plugin.patch"
+                },
+                {
+                     "type":"patch",
+                     "path":"0001-pane-plugin.patch"
+                },
+                {
+                     "type":"patch",
+                     "path":"0001-plugin-installer.patch"
+                }
             ]
         }
     ]

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -41,6 +41,26 @@
                 }
             ]
         },
+
+        {
+            "name": "git",
+            "make-args": [
+                "NO_TCLTK=1",
+                "INSTALL_SYMLINKS=1"
+            ],
+            "make-install-args": [
+                "NO_TCLTK=1",
+                "INSTALL_SYMLINKS=1"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.35.1.tar.gz",
+                    "sha256": "9845a37dd01f9faaa7d8aa2078399d3aea91b43819a5efea6e2877b0af09bd43"
+                }
+            ]
+        },
+
         {
             "name":"liferea",
             "sources":[


### PR DESCRIPTION
Liferea uses `git` to clone the external plugin repository and then it copies the plugin, `git` was missing under the Flatpak sandbox, so installing external plugins was broken.

```
0001-getfocus-plugin.patch
```
From: https://github.com/lwindolf/liferea/pull/1078

```
0001-pane-plugin.patch
```
From: https://github.com/lwindolf/liferea/pull/1081

```
0001-plugin-installer.patch
```
From: https://github.com/lwindolf/liferea/pull/1082

As these three are merged into master, they should be dropped once Liferea 1.13.8 is out.

Now all plugins included by default can write/read/persist their configs under the Flatpak sandbox. Two plugins included in the download section of Liferea plugin installer are still broken, I have made issues for both of them.

Partly resolves https://github.com/flathub/net.sourceforge.liferea/issues/3 (external plugins 4., 5. is out of scope)