### PR TITLE
Release 1.15.1

### DIFF
--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -105,6 +105,10 @@
                 {
                     "type":"patch",
                     "path":"patches/download.patch"
+                },
+                {
+                    "type":"patch",
+                    "path":"patches/about-1.15.1.patch"
                 }
             ]
         }

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -1,7 +1,7 @@
 {
     "app-id":"net.sourceforge.liferea",
     "runtime":"org.gnome.Platform",
-    "runtime-version":"42",
+    "runtime-version":"44",
     "sdk":"org.gnome.Sdk",
     "command":"liferea",
     "cleanup":[

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -37,12 +37,15 @@
             "sources":[
                 {
                     "type":"archive",
-                    "url":"https://download.gnome.org/sources/libpeas/1.34/libpeas-1.34.0.tar.xz",
-                    "sha256":"4305f715dab4b5ad3e8007daec316625e7065a94e63e25ef55eb1efb964a7bf0"
+                    "url":"https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz",
+                    "sha256":"297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libpeas"
+                    }
                 }
             ]
         },
-
         {
             "name": "git",
             "make-args": [
@@ -56,8 +59,14 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.40.0.tar.xz",
-                    "sha256": "b17a598fbf58729ef13b577465eb93b2d484df1201518b708b5044ff623bf46d"
+                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.41.0.tar.xz",
+                    "sha256": "e748bafd424cfe80b212cbc6f1bbccc3a47d4862fb1eb7988877750478568040",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 5350,
+                        "stable-only": true,
+                        "url-template": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$version.tar.xz"
+                    }
                 }
             ]
         },
@@ -71,7 +80,12 @@
                 {
                     "type": "archive",
                     "sha256": "58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5",
-                    "url": "https://github.com/aria2/aria2/releases/download/release-1.36.0/aria2-1.36.0.tar.xz"
+                    "url": "https://github.com/aria2/aria2/releases/download/release-1.36.0/aria2-1.36.0.tar.xz",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 109,
+                        "url-template": "https://github.com/aria2/aria2/releases/download/release-$version/aria2-$version.tar.xz"
+                    }
                 }
             ]
         },

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -95,8 +95,8 @@
                 {
                     "type":"git",
                     "url":"https://github.com/lwindolf/liferea.git",
-                    "tag": "v1.15.0",
-                    "commit":"b63def78a30d1414c3120d857b91b75c423a0e58"
+                    "tag": "v1.15.1",
+                    "commit":"39cf0f8e7f75a3a8daad080f895c095e53e32280"
                 },
                 {
                     "type":"patch",

--- a/patches/about-1.15.1.patch
+++ b/patches/about-1.15.1.patch
@@ -1,0 +1,24 @@
+From f97da84ac1a26b9b8abd41dfd665f7ab2feea99e Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Mon, 14 Aug 2023 22:08:33 +0530
+Subject: [PATCH] Correct version number in about dialogue
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 07868861..7f6009e8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,6 +1,6 @@
+ dnl Process this file with autoconf to produce a configure script.
+ 
+-AC_INIT([liferea],[1.15.0],[liferea-devel@lists.sourceforge.net])
++AC_INIT([liferea],[1.15.1],[liferea-devel@lists.sourceforge.net])
+ AC_CANONICAL_HOST
+ AC_CONFIG_SRCDIR([src/feedlist.c])
+ 
+-- 
+2.41.0
+

--- a/patches/appdata.patch
+++ b/patches/appdata.patch
@@ -1,20 +1,44 @@
-From 4a1cdbf61c1176dd7748e8904c11c24af6499d3f Mon Sep 17 00:00:00 2001
+From c2cd98eb461612838e1a7a695942150a555f852b Mon Sep 17 00:00:00 2001
 From: bbhtt <bbhtt.zn0i8@slmail.me>
 Date: Wed, 19 Apr 2023 06:13:03 +0530
-Subject: [PATCH] Update appdata for 1.15.0
+Subject: [PATCH] Update appdata for 1.15.1
 
 ---
- net.sourceforge.liferea.appdata.xml.in | 21 +++++++++++++++++++++
- 1 file changed, 21 insertions(+)
+ net.sourceforge.liferea.appdata.xml.in | 45 ++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
 
 diff --git a/net.sourceforge.liferea.appdata.xml.in b/net.sourceforge.liferea.appdata.xml.in
-index 2be3345b..b5bd36b9 100644
+index 820c1d3f..5d47efe4 100644
 --- a/net.sourceforge.liferea.appdata.xml.in
 +++ b/net.sourceforge.liferea.appdata.xml.in
-@@ -105,6 +105,27 @@
+@@ -101,6 +101,51 @@
      <content_attribute id="money-gambling">none</content_attribute>
    </content_rating>
    <releases>
++    <release date="2023-08-14" version="1.15.1">
++      <description>
++        <p>This is a new feature release. It introduces the long awaited switch to libsoup3 and libwebkit2gtk-4.1.
++        Thanks to many testers helping testing the latest code from git some errors were ironed out already. Still there is an issue remaining where feed updates are getting stuck when updating while DNS resolution/Wifi/network... fails. Please comment if you also experience this issue! Also noteworthy is a simplification of the debug handling which removes three CLI parameters --debug-performance, --debug-trace and --debug-verbose</p>
++        <ul>Changes
++         <li>Update to libsoup3 and libwebkit2gtk-4.1 (Lars Windolf)</li>
++         <li>Fixes #1285: HTTP 304 incorrectly caused error state (Rich Coe)</li>
++         <li>Fixes #1272: Crash on moving feed into new folder (Lars Windolf)</li>
++         <li>Fixes #1262: Plugin installer: duplicate punctuation (Christian Stadelmann)</li>
++         <li>Fixes #1250: Incorrect item_id when downloading AMP URLs (Alexandre Erwin Ittner)</li>
++         <li>Fixes #1248: Can't maximize for reading feeds (Lars Windolf)</li>
++         <li>Fixes #1242: Dropping not-functioning Pocket bookmark URL (Lars Windolf)</li>
++         <li>Fixes #1241: Dropping not-functioning identi.ca bookmark URL (Lars Windolf)</li>
++         <li>Fixes #1240: TypeError on add-bookmark-site preferences (Lucidiot)</li>
++         <li>Many fixes for static code analysis warnings (Lars Windolf)</li>
++         <li>Simplified debug handling. Drop --debug-performance --debug-trace and --debug-verbose CLI parameters</li>
++         <li>Removed stale Deutsche Welle Brasil feed from pt-BR default feed list (Alexandre Erwin Ittner)</li>
++         <li>Updated appdata description and summary (bbhtt)</li>
++         <li>Add Russian user documentation (slichtzzz)</li>
++         <li>Updated Czech translation (Amerey)</li>
++         <li>Updated Brazilian Portugese translation (Fúlvio Alves)</li>
++        </ul>
++      </description>
++    </release>
 +    <release date="2023-04-17" version="1.15.0">
 +      <description>
 +        <p>This is the first release of the new unstable line 1.15. The current idea is to release a bit
@@ -39,6 +63,6 @@ index 2be3345b..b5bd36b9 100644
      <release date="2023-03-24" version="1.14.3">
        <description>
          <p>This is another 1.14 bugfix release to address a crash affecting some users and a build issue when running tests</p>
---
-2.40.0
+-- 
+2.41.0
 


### PR DESCRIPTION
Looks like there are a bunch of issues with that release like feeds not downloading (mentioned in release notes), deprecated webkit2gtk function warnings, some extensions not working etc. So it's unlikely we can safely upgrade the stable branch to 1.15.1

So I'm keeping this as beta for now.