### PR TITLE
Release 1.15.4

### DIFF
--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -13,7 +13,11 @@
         "/share/doc",
         "/share/gir-1.0",
         "/share/gitweb",
+        "/share/gtk-doc",
         "/share/man",
+        "/share/libayatana-indicator",
+        "/share/libdbusmenu",
+        "/share/vala",
         "*.la",
         "*.a"
     ],

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -191,6 +191,10 @@
                 {
                     "type":"patch",
                     "path":"patches/trayicon.patch"
+                },
+                {
+                    "type":"patch",
+                    "path":"patches/prgname.patch"
                 }
             ]
         }

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -96,6 +96,73 @@
             ]
         },
         {
+            "name": "libdbusmenu-gtk3",
+            "buildsystem": "autotools",
+            "build-options": {
+                "cflags": "-Wno-error"
+            },
+            "config-opts": [
+                "--with-gtk=3",
+                "--disable-dumper",
+                "--disable-static",
+                "--disable-gtk-doc",
+                "--enable-introspection=no",
+                "--disable-vala"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz",
+                    "sha256": "b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
+                }
+            ]
+        },
+        {
+            "name": "ayatana-ido",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/AyatanaIndicators/ayatana-ido.git",
+                    "tag": "0.10.1",
+                    "commit": "13402a2cc4616b4b5f4244413599e635fcfc1401"
+                }
+            ]
+        },
+        {
+            "name": "libayatana-indicator",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/AyatanaIndicators/libayatana-indicator.git",
+                    "tag": "0.9.4",
+                    "commit": "611bb384b73fa6311777ba4c41381a06f5b99dad"
+                }
+            ]
+        },
+        {
+            "name": "libayatana-appindicator",
+            "buildsystem": "cmake-ninja",
+            "build-options": {
+                "env": {
+                    "LIBRARY_PATH": "/app/lib:$LIBRARY_PATH"
+                }
+            },
+            "config-opts": [
+                "-DENABLE_BINDINGS_MONO=NO",
+                "-DENABLE_BINDINGS_VALA=NO"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/AyatanaIndicators/libayatana-appindicator.git",
+                    "tag": "0.5.93",
+                    "commit": "238c8b02718fa5b4af95ede72beeed762094f4cc"
+                }
+            ]
+        },
+        {
             "name":"liferea",
             "sources":[
                 {

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -98,8 +98,8 @@
                 {
                     "type":"git",
                     "url":"https://github.com/lwindolf/liferea.git",
-                    "tag": "v1.15.3",
-                    "commit":"05561d523df315f3266746a3f7daaa363b6ce78e"
+                    "tag": "v1.15.4",
+                    "commit":"508e7a970088873f6503b8c8df08dac6ae14963c"
                 },
                 {
                     "type":"patch",

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -187,6 +187,10 @@
                 {
                     "type":"patch",
                     "path":"patches/trayicon-config-path.patch"
+                },
+                {
+                    "type":"patch",
+                    "path":"patches/trayicon.patch"
                 }
             ]
         }

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -30,7 +30,8 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.freedesktop.secrets"
+        "--talk-name=org.freedesktop.secrets",
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules":[
         "shared-modules/intltool/intltool-0.51.json",

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -44,7 +44,10 @@
                     "sha256":"297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "libpeas"
+                        "name": "libpeas",
+                        "versions": {
+                            "<": "1.99"
+                         }
                     }
                 }
             ]

--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -178,6 +178,10 @@
                 {
                     "type":"patch",
                     "path":"patches/download.patch"
+                },
+                {
+                    "type":"patch",
+                    "path":"patches/trayicon-config-path.patch"
                 }
             ]
         }

--- a/patches/appdata.patch
+++ b/patches/appdata.patch
@@ -1,33 +1,26 @@
-From aa1a9d6484db79245268a0fba37d92ec7c353b72 Mon Sep 17 00:00:00 2001
-From: bbhtt <bbhtt.zn0i8@slmail.me>
-Date: Sat, 16 Sep 2023 07:42:57 +0530
-Subject: [PATCH] Appdata changes for 1.15.3
-
----
- net.sourceforge.liferea.appdata.xml.in | 10 ++++++++++
- 1 file changed, 10 insertions(+)
-
 diff --git a/net.sourceforge.liferea.appdata.xml.in b/net.sourceforge.liferea.appdata.xml.in
-index 9e60a685..4b150962 100644
+index 4b150962..6c47d434 100644
 --- a/net.sourceforge.liferea.appdata.xml.in
 +++ b/net.sourceforge.liferea.appdata.xml.in
-@@ -101,6 +101,16 @@
+@@ -101,6 +101,21 @@
      <content_attribute id="money-gambling">none</content_attribute>
    </content_rating>
    <releases>
-+    <release date="2023-09-16" version="1.15.3">
++    <release date="2023-10-23" version="1.15.4">
 +      <description>
-+        <p>This is a new bugfix release for 1.15</p>
++        <p>This release brings small fixes and a rework of the trayicon plugin</p>
++        <p>Thanks to the work of Yuri Konotopov the trayicon plugin now supports AppIndicator
++        and libayatana. The important difference here is that the new item counter can be shown
++        as a text label next to the icon which makes for much improved rendering.</p>
++        <p>There are some limitations though as AppIndicator might not work perfect in all implementations
++        (e.g. XFCE).</p>
 +        <ul>Changes
-+          <li>Fixes #1297: Enabling plugin 'webkit-settings' crashes Liferea (reported by Paul Gevers)</li>
-+          <li>Fixes #1294: Clicking 'remove item' caused a SIGSEGV (reported by Rich Coe)</li>
-+          <li>Fixes #1276: Old WebKitCache cache not cleaned (reported by hasezoey)</li>
++          <li>Improve on #1192 by doing pane sanity checks on each resize (Lars Windolf)</li>
++          <li>Fixes #1297: Reorder loading plugins and deactivating webkit-settings (Lars Windolf)</li>
++          <li>#1305 Refactoring of the trayicon plugin to support AppIndicator and libayatana (Yuri Konotopov)</li>
 +        </ul>
 +      </description>
 +    </release>
-     <release date="2023-08-30" version="1.15.2">
+     <release date="2023-09-16" version="1.15.3">
        <description>
-         <p>This is a bugfix release. It provides an important stability fix regarding feed parsing. Kudos to Rich Coe for debugging and fixing the issue!</p>
---
-2.41.0
-
+         <p>This is a new bugfix release for 1.15</p>

--- a/patches/prgname.patch
+++ b/patches/prgname.patch
@@ -1,0 +1,41 @@
+From 82e81a5f51199e0aa47d9f2b055e35d3e674e29c Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Mon, 23 Oct 2023 14:16:57 +0530
+Subject: [PATCH] Set prgname to match the reverse dns style application id
+
+When launched on wayland with `WAYLAND_DEBUG=1` Liferea sets the app id
+"liferea" but not net.sourceforge.liferea:
+
+```
+[1225601.077]  -> xdg_toplevel@41.set_app_id("liferea")
+```
+
+When launched on KDE Wayland session, it expects the desktop file name
+to match the application id to look up the correct app icon to show in
+taskbar app swicther etc. But instead it tries too look up an icon
+called "liferea" which does not exist. So liferea shows up with the
+default wayland icon instead of the app icon.
+
+Setting WM_CLASS here won't work and we can't export two desktop files.
+
+This does not effect GNOME because it tries harder to guess the app icon
+---
+ src/liferea_application.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/liferea_application.c b/src/liferea_application.c
+index f099beef..11ea2468 100644
+--- a/src/liferea_application.c
++++ b/src/liferea_application.c
+@@ -337,7 +337,7 @@ liferea_application_new (int argc, char *argv[])
+ 		                    "application-id", "net.sourceforge.liferea",
+ 		                    NULL);
+ 
+-	g_set_prgname ("liferea");
++	g_set_prgname ("net.sourceforge.liferea");
+ 	g_set_application_name (_("Liferea"));
+ 	gtk_window_set_default_icon_name ("net.sourceforge.liferea");	/* GTK theme support */
+ 	status = g_application_run (G_APPLICATION (liferea_app), argc, argv);
+-- 
+2.41.0
+

--- a/patches/trayicon-config-path.patch
+++ b/patches/trayicon-config-path.patch
@@ -1,0 +1,49 @@
+From 7272c6d5547b694dcb3bc80071b3b80acba73fd0 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Mon, 23 Oct 2023 10:08:19 +0530
+Subject: [PATCH] Support XDG_CONFIG_HOME when saving trayicon plugin config
+
+---
+ plugins/trayicon.py | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/plugins/trayicon.py b/plugins/trayicon.py
+index f3d66bb9..9922c021 100644
+--- a/plugins/trayicon.py
++++ b/plugins/trayicon.py
+@@ -18,7 +18,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ """
+ 
+ import gettext
++import os
+ import pathlib
++from pathlib import Path
+ from collections import namedtuple
+ import cairo
+ import gi
+@@ -100,15 +102,15 @@ def pixbuf_text(width, height, text, font_size=16, bg_pix=None):
+ 
+ 
+ def get_config_path():
+-    """Return data file path"""
+-    data_dir = pathlib.Path.joinpath(
+-        pathlib.Path.home(),
+-        ".config/liferea/plugins/trayicon"
+-    )
+-    if not data_dir.exists():
+-        data_dir.mkdir(0o700, True, True)
++    """Return config file path"""
++    trayicon_path = "liferea/plugins/trayicon"
++    config_home = os.getenv('XDG_CONFIG_HOME',Path.joinpath(Path.home(), ".config"))
++    config_dir = Path.joinpath(Path(config_home), trayicon_path)
++
++    if not config_dir.exists():
++        config_dir.mkdir(0o700, True, True)
+ 
+-    config_path = data_dir / "trayicon.conf"
++    config_path = config_dir / "trayicon.conf"
+     return config_path
+ 
+ 
+-- 
+2.41.0

--- a/patches/trayicon.patch
+++ b/patches/trayicon.patch
@@ -1,0 +1,44 @@
+--- liferea/plugins/trayicon.py	2023-10-23 12:16:38.771381887 +0530
++++ liferea/plugins/trayicon.py	2023-10-23 12:13:13.126260219 +0530
+@@ -157,20 +159,20 @@
+         if self.use_appindicator:
+             self.indicator = AppIndicator.Indicator.new(
+                 "Liferea",
+-                Liferea.icon_find_pixmap_file("emblem-web.svg"),
++                "net.sourceforge.liferea",
+                 AppIndicator.IndicatorCategory.APPLICATION_STATUS
+             )
+ 
+             self.indicator.set_attention_icon_full(
+-                Liferea.icon_find_pixmap_file("unread.png"),
++                "net.sourceforge.liferea",
+                 _("Liferea unread icon")
+             )
+             self.indicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
+             self.indicator.set_title("Liferea")
+         else:
+-            self.read_pix = Liferea.icon_create_from_file("emblem-web.svg")
++            self.read_pix = "net.sourceforge.liferea"
+             # FIXME: Support a scalable image!
+-            self.unread_pix = Liferea.icon_create_from_file("unread.png")
++            self.unread_pix = "net.sourceforge.liferea"
+ 
+             self.staticon = Gtk.StatusIcon ()
+             self.staticon.connect("activate", self.trayicon_click)
+@@ -314,7 +316,7 @@
+                 # Workaround Mate bug
+                 # See also: https://github.com/mate-desktop/mate-panel/issues/1412
+                 self.indicator.set_icon_full(
+-                    Liferea.icon_find_pixmap_file("unread.png"),
++                    "net.sourceforge.liferea",
+                     _("Liferea unread icon")
+                 )
+ 
+@@ -324,7 +326,7 @@
+                 # Workaround Mate bug
+                 # See also: https://github.com/mate-desktop/mate-panel/issues/1412
+                 self.indicator.set_icon_full(
+-                    Liferea.icon_find_pixmap_file("emblem-web.svg"),
++                    "net.sourceforge.liferea",
+                     _("Liferea")
+                 )


### PR DESCRIPTION
The tray menu works but no icon shows up on GNOME 45/Wayland (using https://extensions.gnome.org/extension/615/appindicator-support/). 

Setting, debug logging on the extension:

```
$ cat /etc/environment

G_MESSAGES_DEBUG=AppIndicator-and-KStatusNotifierItem-Support
```

shows it is getting the correct icon path from `/app/share/liferea/pixmaps` and gdk-pixbuf from runtime comes with both png and svg loaders. 

Running with `--socket=session-bus` or `--log-session-bus` shows no missing permissions.

So I have no idea what goes wrong.